### PR TITLE
Handle additional props

### DIFF
--- a/test/construct-image.spec.js
+++ b/test/construct-image.spec.js
@@ -5,9 +5,16 @@ import { constructImage } from '../src/construct-picture'
 //-----------------------------------------------------------------------------
 
 describe('Construct Image', () => {
-  it('correctly builds src', () => {
+  it.only('correctly builds src', () => {
     const spec = {
       src: {
+        width: '240px',
+        ratio: '16 / 9',
+        options: {
+          quality: 50,
+        },
+      },
+      placeholder: {
         width: '240px',
         ratio: '16 / 9',
         options: {

--- a/test/construct-image.spec.js
+++ b/test/construct-image.spec.js
@@ -5,7 +5,7 @@ import { constructImage } from '../src/construct-picture'
 //-----------------------------------------------------------------------------
 
 describe('Construct Image', () => {
-  it.only('correctly builds src', () => {
+  it('correctly builds src', () => {
     const spec = {
       src: {
         width: '240px',
@@ -18,7 +18,7 @@ describe('Construct Image', () => {
         width: '240px',
         ratio: '16 / 9',
         options: {
-          quality: 50,
+          quality: 75,
         },
       },
       sizes: '50vw',
@@ -39,13 +39,14 @@ describe('Construct Image', () => {
     // ----------------------------------------
 
     const expected = {
+      placeholder: `https://picsum.photos/id/128/240/135?q=75&crop=auto`,
       src: `https://picsum.photos/id/128/240/135?q=50&crop=auto`,
       sizes: '50vw',
     }
 
     // ----------------------------------------
 
-    const result = constructImage(spec, template, image)
+    const result = constructImage(template, spec, image)
 
     expect(result).to.deep.equal(expected)
   })
@@ -95,7 +96,7 @@ describe('Construct Image', () => {
 
     // ----------------------------------------
 
-    const result = constructImage(spec, template, image)
+    const result = constructImage(template, spec, image)
 
     // console.log(result)
 

--- a/test/construct-picture.spec.js
+++ b/test/construct-picture.spec.js
@@ -4,7 +4,7 @@ import { constructPicture } from '../src/construct-picture'
 
 //-----------------------------------------------------------------------------
 
-describe('Build Picture', () => {
+describe('Construct Picture', () => {
   it('given an image data object, picture specification and url template, build a final picture props object', () => {
     // Example of the kind of specification that might be generated
     // within a template or view layer, and combined with instance data (see below)
@@ -44,6 +44,13 @@ describe('Build Picture', () => {
           ratio: '16 / 9',
           options: {
             quality: 50,
+          },
+        },
+        'data-src': {
+          width: '240px',
+          ratio: '16 / 9',
+          options: {
+            quality: 70,
           },
         },
         srcset: {
@@ -96,6 +103,7 @@ describe('Build Picture', () => {
       ],
       img: {
         src: 'https://picsum.photos/id/128/240/135?q=50&crop=auto',
+        'data-src': 'https://picsum.photos/id/128/240/135?q=70&crop=auto',
 
         // Note the missing {quality} token below!
         srcset: [
@@ -109,7 +117,7 @@ describe('Build Picture', () => {
 
     // ----------------------------------------
 
-    const result = constructPicture(spec, template, image)
+    const result = constructPicture(template, spec, image)
 
     // console.log(result)
 


### PR DESCRIPTION
Allow arbitrary props to be specified as `src` or `srcset` in spec. E.g.: `data-src`, `placeholder`, etc.